### PR TITLE
feat: action can be run on the same workflow as preview-build-action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: composite
   steps:
-  - name: Download Artifacts from triggered workflow
+  - name: Download Artifacts from triggerer workflow
     uses: dawidd6/action-download-artifact@v2
     with:
       workflow: ${{ github.event.workflow_run.workflow_id }}

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ runs:
       run_id: ${{ github.event.workflow_run.id }}
     # running this step only if this action was run by `on.workflow_run`
     if: >
-      github.event.workflow_run.conclusion == 'success'
+      github.event.workflow_run.conclusion != null
   - name: Download Artifacts from current workflow
     uses: actions/download-artifact@v3
     # running this step only if this action running in the same workflow as preview-build-action's workflow

--- a/action.yml
+++ b/action.yml
@@ -19,11 +19,19 @@ inputs:
 runs:
   using: composite
   steps:
-  - name: Download Artifacts
+  - name: Download Artifacts from triggered workflow
     uses: dawidd6/action-download-artifact@v2
     with:
       workflow: ${{ github.event.workflow_run.workflow_id }}
       run_id: ${{ github.event.workflow_run.id }}
+    # running this step only if this action was run by `on.workflow_run`
+    if: >
+      github.event.workflow_run.conclusion == 'success'
+  - name: Download Artifacts from current workflow
+    uses: actions/download-artifact@v3
+    # running this step only if this action running in the same workflow as preview-build-action's workflow
+    if: >
+      github.event.workflow_run.conclusion == null
   - name: Extract PR Number
     id: pr
     run: echo "::set-output name=id::$(<pr/pr-id.txt)"


### PR DESCRIPTION
Action `dawidd6/action-download-artifact` is intended to download artifacts from another workflow, so this action cannot work properly with https://github.com/gravity-ui/preview-build-action/ within the same workflow. This PR allows to use this action in both cases